### PR TITLE
Support Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - nightly
   - pypy
   - pypy3
 install:

--- a/pep8.py
+++ b/pep8.py
@@ -1328,7 +1328,7 @@ def register_check(check, codes=None):
                 codes = ERRORCODE_REGEX.findall(check.__doc__ or '')
             _add_check(check, args[0], codes, args)
     elif inspect.isclass(check):
-        if sys.version_info[0] >= 3:
+        if sys.version_info >= (3, 3):
             parameters = list(inspect.signature(check.__init__).parameters)
         else:
             parameters = inspect.getargspec(check.__init__)[0]

--- a/pep8.py
+++ b/pep8.py
@@ -1328,7 +1328,12 @@ def register_check(check, codes=None):
                 codes = ERRORCODE_REGEX.findall(check.__doc__ or '')
             _add_check(check, args[0], codes, args)
     elif inspect.isclass(check):
-        if inspect.getargspec(check.__init__)[0][:2] == ['self', 'tree']:
+        if sys.version_info[0] >= 3:
+            parameters = list(inspect.signature(check.__init__).parameters)
+        else:
+            parameters = inspect.getargspec(check.__init__)[0]
+
+        if parameters[:2] == ['self', 'tree']:
             _add_check(check, 'tree', codes, None)
 
 
@@ -1504,7 +1509,7 @@ class Checker(object):
         """Build the file's AST and run all AST checks."""
         try:
             tree = compile(''.join(self.lines), '', 'exec', PyCF_ONLY_AST)
-        except (SyntaxError, TypeError):
+        except (ValueError, SyntaxError, TypeError):
             return self.report_invalid_syntax()
         for name, cls, __ in self._ast_checks:
             checker = cls(tree, self.filename)

--- a/testsuite/test_api.py
+++ b/testsuite/test_api.py
@@ -339,6 +339,9 @@ class APITestCase(unittest.TestCase):
         if 'SyntaxError' in stdout:
             # PyPy 2.2 returns a SyntaxError
             expected = "stdin:1:2: E901 SyntaxError"
+        elif 'ValueError' in stdout:
+            # Python 3.5.
+            expected = "stdin:1:1: E901 ValueError"
         else:
             expected = "stdin:1:1: E901 TypeError"
         self.assertTrue(stdout.startswith(expected),


### PR DESCRIPTION
This involves fixing a test and avoiding a function deprecated since Python 3.0.

https://docs.python.org/dev/library/inspect.html#inspect.getargspec