### PR TITLE
Remove pypy* from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 python:
   - 2.6
   - 2.7
@@ -15,10 +16,6 @@ script:
   - python pep8.py --statistics pep8.py
   - python pep8.py --doctest
   - python setup.py test
-matrix:
-  allow_failures:
-    - python: pypy
-    - python: pypy3
 
 notifications:
   email:


### PR DESCRIPTION
The pypy jobs have not failed in a long time. Keeping them in
allowed_failures means that if they start failing, no one will notice
them.

We also start using "sudo: false" since we are not installing anything
with apt and this will speed up build times.