### PR TITLE
Multi-line ignore parsing in config_file

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -2081,10 +2081,10 @@ def process_options(arglist=None, parse_argv=False, config_file=None,
         options = read_config(options, args, arglist, parser)
         options.reporter = parse_argv and options.quiet == 1 and FileReport
 
-    options.filename = options.filename and options.filename.split(',')
+    options.filename = _parse_multi_options(options.filename.split(','))
     options.exclude = normalize_paths(options.exclude)
-    options.select = options.select and options.select.split(',')
-    options.ignore = options.ignore and options.ignore.split(',')
+    options.select = _parse_multi_options(options.select.split(','))
+    options.ignore = _parse_multi_options(options.ignore.split(','))
 
     if options.diff:
         options.reporter = DiffReport
@@ -2093,6 +2093,22 @@ def process_options(arglist=None, parse_argv=False, config_file=None,
         args = sorted(options.selected_lines)
 
     return options, args
+
+
+def _parse_multi_options(options):
+    r"""Split and strip and discard empties.
+
+    Turns the following:
+
+    A,
+    B,
+
+    into ["A", "B"]
+    """
+    if options:
+        return [o.strip() for o in options if o.strip()]
+    else:
+        return options
 
 
 def _main():

--- a/testsuite/test_all.py
+++ b/testsuite/test_all.py
@@ -46,11 +46,12 @@ class Pep8TestCase(unittest.TestCase):
 
 
 def suite():
-    from testsuite import test_api, test_shell, test_util
+    from testsuite import test_api, test_parser, test_shell, test_util
 
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(Pep8TestCase))
     suite.addTest(unittest.makeSuite(test_api.APITestCase))
+    suite.addTest(unittest.makeSuite(test_parser.ParserTestCase))
     suite.addTest(unittest.makeSuite(test_shell.ShellTestCase))
     suite.addTest(unittest.makeSuite(test_util.UtilTestCase))
     return suite

--- a/testsuite/test_parser.py
+++ b/testsuite/test_parser.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+import unittest
+
+import pep8
+
+
+def _process_file(contents):
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(contents)
+
+    options, args = pep8.process_options(config_file=f.name)
+    os.remove(f.name)
+
+    return options, args
+
+
+class ParserTestCase(unittest.TestCase):
+
+    def test_vanilla_ignore_parsing(self):
+        contents = b"""
+[pep8]
+ignore = E226,E24
+        """
+        options, args = _process_file(contents)
+
+        self.assertEqual(options.ignore, ["E226", "E24"])
+
+    def test_multiline_ignore_parsing(self):
+        contents = b"""
+[pep8]
+ignore =
+    E226,
+    E24
+        """
+
+        options, args = _process_file(contents)
+
+        self.assertEqual(options.ignore, ["E226", "E24"])
+
+    def test_trailing_comma_ignore_parsing(self):
+        contents = b"""
+[pep8]
+ignore = E226,
+        """
+
+        options, args = _process_file(contents)
+
+        self.assertEqual(options.ignore, ["E226"])
+
+    def test_multiline_trailing_comma_ignore_parsing(self):
+        contents = b"""
+[pep8]
+ignore =
+    E226,
+    E24,
+        """
+
+        options, args = _process_file(contents)
+
+        self.assertEqual(options.ignore, ["E226", "E24"])


### PR DESCRIPTION
In `tox.ini` it is entirely possible to have multi-line lists with trailing commas, e.g.

```
envlist =
    py27,
    py34,
```

If however you do

```
[pep8]
ignore =
    E1,
    E2,
```

then `options.ignore` ends up as `('\nE1', \nE2', '')`

The first two items of that tuple are "mildly inconvenient"; the preceding `\n` just means the ignore is...ignored - a consequence of the multiline

The empty string as the last item, a consequence of the trailing comma, is much more insidious, as it causes all checks to be silently ignored thanks to https://github.com/PyCQA/pep8/blob/master/pep8.py#L1890-L1901, specifically

```
return (code.startswith(self.options.ignore) and
                not code.startswith(self.options.select))
```

Currently, this PR includes some py27 tests to demonstrate this behaviour (I haven't tested my tests in other environments yet; am letting Travis do that for me) - I'll try to follow up with an actual fix.

Ultimately, the "real problem" here is probably "parsing another tool's config file"; there'll always be fun quirks etc., but that's much harder to do anything about!

