### PR TITLE
Add optional getfullargspec for > PY36 compat

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1318,6 +1318,8 @@ def _get_parameters(function):
     if sys.version_info >= (3, 3):
         return list(inspect.signature(function).parameters)
     else:
+        if hasattr(inspect, 'getfullargspec'):
+            return inspect.getfullargspec(function)[0]
         return inspect.getargspec(function)[0]
 
 


### PR DESCRIPTION
The inspect.getargspec() function has been deprecated in PY3X and
finally removed in PY36. This patch adds optional use of the
inspect.getfullargspec() function which replaces it.