### PR TITLE
Correct _get_parameters.

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1316,7 +1316,10 @@ _checks = {'physical_line': {}, 'logical_line': {}, 'tree': {}}
 
 def _get_parameters(function):
     if sys.version_info >= (3, 3):
-        return list(inspect.signature(function).parameters)
+        return [parameter.name
+                for parameter
+                in inspect.signature(function).parameters.values()
+                if parameter.kind == parameter.POSITIONAL_OR_KEYWORD]
     else:
         return inspect.getargspec(function)[0]
 


### PR DESCRIPTION
The two versions of parameter parsing were not, in fact, equivalent. The
return types of `inspect.signature` and `inspect.getargspec` are, in
fact, subtly different.

See:
    * https://docs.python.org/3/library/inspect.html#inspect.signature
    * https://github.com/praw-dev/praw/issues/541#issuecomment-152280322