### PR TITLE
fix BytesWarning on Python 3

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1171,7 +1171,7 @@ def python_3000_backticks(logical_line):
 ##############################################################################
 
 
-if '' == ''.encode():
+if sys.version_info < (3,):
     # Python 2: implicit encoding.
     def readlines(filename):
         """Read the source code."""


### PR DESCRIPTION
On Python 3, when python3 with run with -bb, comparison between bytes
and str raises a BytesWarning exception. Test the Python version
instead of testing '' == b''.